### PR TITLE
Upgrade Springdoc to version 2.8.5

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.3.0</version>
+			<version>2.8.5</version>
     	</dependency>
 	</dependencies>
 


### PR DESCRIPTION
# This PR updates the Springdoc dependency to version 2.8.5.
The previous version caused issues that prevented Swagger UI from loading properly.
Upgrading resolves the access problem and restores normal Swagger UI functionality.
No other functional changes are introduced.